### PR TITLE
fixed factors for spin-adapted 4-RDMs

### DIFF
--- a/sqaSpinAdapted.py
+++ b/sqaSpinAdapted.py
@@ -2159,7 +2159,7 @@ def convert_rdms_si_to_sa(_terms_rdm_si):
                     ## Spin-Adapted RDM term: rdm(p,q,r,s,u,t,v,w)
                     ten_rdm4_sa = ten_rdm4.copy()
                     ten_rdm4_sa.indices = [ten_rdm4_sa.indices[i] for i in [0, 1, 2, 3, 6, 7, 5, 4]]
-                    const_rdm4_sa = - 1.0 / 10.0
+                    const_rdm4_sa = 1.0 / 10.0
 
                     ten_rdm4_tens_sa.append(ten_rdm4_sa)
                     const_rdm4_tens_sa.append(const_rdm4_sa)
@@ -2434,7 +2434,7 @@ def convert_rdms_si_to_sa(_terms_rdm_si):
                     ## Spin-Adapted RDM term: rdm(p,q,r,s,w,u,t,v)
                     ten_rdm4_sa = ten_rdm4.copy()
                     ten_rdm4_sa.indices = [ten_rdm4_sa.indices[i] for i in [0, 1, 2, 3, 4, 6, 7, 5]]
-                    const_rdm4_sa = 1.0 / 20.0
+                    const_rdm4_sa = - 1.0 / 20.0
 
                     ten_rdm4_tens_sa.append(ten_rdm4_sa)
                     const_rdm4_tens_sa.append(const_rdm4_sa)
@@ -3071,7 +3071,7 @@ def convert_rdms_si_to_sa(_terms_rdm_si):
                     ## Spin-Adapted RDM term: rdm(p,q,r,s,t,u,v,w)
                     ten_rdm4_sa = ten_rdm4.copy()
                     ten_rdm4_sa.indices = [ten_rdm4_sa.indices[i] for i in [0, 1, 2, 3, 7, 6, 5, 4]]
-                    const_rdm4_sa = 1.0 / 30.0
+                    const_rdm4_sa = - 1.0 / 30.0
 
                     ten_rdm4_tens_sa.append(ten_rdm4_sa)
                     const_rdm4_tens_sa.append(const_rdm4_sa)
@@ -3459,7 +3459,7 @@ def convert_rdms_si_to_sa(_terms_rdm_si):
                     ## Spin-Adapted RDM term: rdm(p,q,r,s,u,w,t,v)
                     ten_rdm4_sa = ten_rdm4.copy()
                     ten_rdm4_sa.indices = [ten_rdm4_sa.indices[i] for i in [0, 1, 2, 3, 6, 4, 7, 5]]
-                    const_rdm4_sa = 1.0 / 20.0
+                    const_rdm4_sa = - 3.0 / 20.0
 
                     ten_rdm4_tens_sa.append(ten_rdm4_sa)
                     const_rdm4_tens_sa.append(const_rdm4_sa)
@@ -3467,7 +3467,7 @@ def convert_rdms_si_to_sa(_terms_rdm_si):
                     ## Spin-Adapted RDM term: rdm(p,q,r,s,t,w,u,v)
                     ten_rdm4_sa = ten_rdm4.copy()
                     ten_rdm4_sa.indices = [ten_rdm4_sa.indices[i] for i in [0, 1, 2, 3, 7, 4, 6, 5]]
-                    const_rdm4_sa = - 3.0 / 20.0
+                    const_rdm4_sa = - 1.0 / 20.0
 
                     ten_rdm4_tens_sa.append(ten_rdm4_sa)
                     const_rdm4_tens_sa.append(const_rdm4_sa)


### PR DESCRIPTION
There were 4-RDM spin cases that were improperly spin-adapted, this pull request fixes those spin cases by correcting factors in the sqaSpinAdapted.py file.