### PR TITLE
Enabling spin adaptation of terms that depend on transition RDMs

### DIFF
--- a/examples/QDNEVPT2/TV.dat
+++ b/examples/QDNEVPT2/TV.dat
@@ -1,0 +1,445 @@
+
+----------------------------------------------------------------------------------------------------
+sqa_plus: Code generator for quasi-particle systems.
+Copyright 2009-2022 SecondQuantizationAlgebra Developers. All Rights Reserved.
+Available at https://github.com/sokolov-group/sqa_plus
+
+Licensed under the GNU General Public License v3.0;
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+----------------------------------------------------------------------------------------------------
+
+# Create spin-integrated V operator ...
+
+## Calculate 0.5 * <|T+ * V|> ...
+
+------------------------------------------ SQA Automation ------------------------------------------
+
+Computing expectation value with respect to virtual ...
+Done!
+----------------------------------------------------------------------------------------------------
+Normal ordering with respect to core ...
+Done!
+----------------------------------------------------------------------------------------------------
+Computing expectation value with respect to core ...
+Done!
+----------------------------------------------------------------------------------------------------
+Contract delta function for non-dummy indices ...
+Done!
+----------------------------------------------------------------------------------------------------
+Reordering indices according to core < active < virtual...
+Done!
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+
+------------------------------------------ Final results -------------------------------------------
+
+ (   0.50000) h(i,x) t1(i,x) 
+ (   0.50000) h(i,a) t1(i,a) 
+ (   0.50000) h(i,x) t1(i,x) 
+ (   0.50000) h(i,a) t1(i,a) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (   0.12500) t1(i,j,x,y) v(i,j,x,y) 
+ (   0.25000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.12500) t1(i,j,a,b) v(i,j,a,b) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (   0.50000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.50000) t1(i,j,x,y) v(i,j,x,y) 
+ (   0.50000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.50000) t1(i,j,a,b) v(i,j,a,b) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (   0.12500) t1(i,j,x,y) v(i,j,x,y) 
+ (   0.25000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.12500) t1(i,j,a,b) v(i,j,a,b) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (  -0.50000) h(i,x) t1(i,y) cre(x) des(y) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(y) des(z) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(y) des(z) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(x) des(y) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(x) des(y) 
+ (   0.50000) h(x,a) t1(y,a) cre(y) des(x) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(y) des(z) 
+ (  -0.50000) h(i,x) t1(i,y) cre(x) des(y) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(y) des(z) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(x) des(y) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(x) des(y) 
+ (   0.50000) h(x,a) t1(y,a) cre(y) des(x) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(x) des(y) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(x) des(y) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(z) des(y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(y) des(x) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(z) des(y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(y) des(x) 
+ (   0.25000) t1(i,x,y,z) v(i,w,y,z) cre(x) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (   0.25000) t1(i,x,a,b) v(i,y,a,b) cre(x) des(y) 
+ (  -0.25000) t1(i,j,x,y) v(i,j,x,z) cre(z) des(y) 
+ (  -0.25000) t1(i,j,a,x) v(i,j,a,y) cre(y) des(x) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(y) des(x) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(y) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (   0.50000) t1(i,x,y,z) v(i,w,y,z) cre(x) des(w) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(x) des(z) 
+ (   0.50000) t1(i,x,a,b) v(i,y,a,b) cre(x) des(y) 
+ (  -0.50000) t1(i,j,a,x) v(i,j,a,y) cre(y) des(x) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(x) des(y) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(x) des(y) 
+ (   0.50000) t1(i,x,y,z) v(i,w,y,z) cre(x) des(w) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(x) des(z) 
+ (   0.50000) t1(i,x,a,b) v(i,y,a,b) cre(x) des(y) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (  -0.50000) t1(i,j,x,y) v(i,j,x,z) cre(z) des(y) 
+ (  -0.50000) t1(i,j,a,x) v(i,j,a,y) cre(y) des(x) 
+ (  -0.50000) t1(i,j,x,y) v(i,j,x,z) cre(z) des(y) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(z) des(y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(y) des(x) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(z) des(y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(y) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (   0.25000) t1(i,x,y,z) v(i,w,y,z) cre(x) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(x) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(x) des(y) 
+ (   0.25000) t1(i,x,a,b) v(i,y,a,b) cre(x) des(y) 
+ (  -0.25000) t1(i,j,x,y) v(i,j,x,z) cre(z) des(y) 
+ (  -0.25000) t1(i,j,a,x) v(i,j,a,y) cre(y) des(x) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(y) des(x) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(y) des(x) 
+ (   0.25000) h(i,x) t1(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (   0.50000) h(i,x) t1(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (  -0.25000) h(x,a) t1(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) h(x,a) t1(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (   0.50000) h(i,x) t1(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (   0.25000) h(i,x) t1(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (  -0.50000) h(x,a) t1(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.25000) h(x,a) t1(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.12500) t1(x,y,a,z) v(w,u,a,z) cre(x) cre(y) des(w) des(u) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (  -0.06250) t1(x,y,a,b) v(z,w,a,b) cre(x) cre(y) des(z) des(w) 
+ (  -0.25000) t1(x,a) v(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(x,a) v(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(x,y,a,z) v(w,u,a,z) cre(x) cre(y) des(w) des(u) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (   0.25000) t1(i,x) v(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (   0.50000) t1(i,x) v(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.06250) t1(i,j,x,y) v(i,j,z,w) cre(z) cre(w) des(x) des(y) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (  -0.50000) t1(x,y,a,z) v(w,u,a,z) cre(x) cre(y) des(w) des(u) 
+ (  -0.50000) t1(x,y,a,b) v(z,w,a,b) cre(x) cre(y) des(z) des(w) 
+ (  -0.12500) t1(x,y,a,z) v(w,u,a,z) cre(x) cre(y) des(w) des(u) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(x) cre(y) des(z) des(w) 
+ (  -0.06250) t1(x,y,a,b) v(z,w,a,b) cre(x) cre(y) des(z) des(w) 
+ (  -0.50000) t1(x,a) v(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.25000) t1(x,a) v(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,j,x,y) v(i,j,z,w) cre(z) cre(w) des(x) des(y) 
+ (   0.50000) t1(i,x) v(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (   0.25000) t1(i,x) v(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(x) cre(u) des(z) des(w) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.06250) t1(i,j,x,y) v(i,j,z,w) cre(z) cre(w) des(x) des(y) 
+ (   0.12500) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (   0.50000) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (  -0.12500) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (   0.50000) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (   0.12500) t1(x,y,a,z) v(w,u,a,v) cre(x) cre(y) cre(v) des(z) des(w) des(u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+ (  -0.12500) t1(i,x,y,z) v(i,w,u,v) cre(x) cre(u) cre(v) des(y) des(z) des(w) 
+
+Total terms : 166
+SQA automation time :  63.293 seconds
+
+------------------------ Converting Spin-Integrated Tensors to Spin-Adapted ------------------------
+
+----------------------------------------------------------------------------------------------------
+Convert Cre/Des objects to RDM objects...
+Done!
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+Converting 1e- integrals to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+Converting 2e- integrals to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+Converting T amplitudes to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+Converting RDMs to spin-adapted formulation...
+
+Converting 1-RDMs to spin-adapted formulation...
+Converting 2-RDMs to spin-adapted formulation...
+Converting 3-RDMs to spin-adapted formulation...
+Converting 4-RDMs to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+
+Combining 556 spin-adapted terms...
+
+Reorder 2e- integrals in Chemists' notation...
+Done!
+----------------------------------------------------------------------------------------------------
+Reorder RDM tensor indices in Chemists' notation...
+Done!
+----------------------------------------------------------------------------------------------------
+Reordering indices according to core < active < virtual...
+Done!
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+
+479 spin-adapted terms combined.
+----------------------------------------------------------------------------------------------------
+
+-------------------------------------- Spin-adapted equations --------------------------------------
+
+ (   1.00000) h(i,a) t1(i,a) 
+ (   1.00000) h(i,x) t1(i,x) 
+ (  -1.00000) t1(i,a) v(i,j,j,a) 
+ (   2.00000) t1(i,a) v(j,j,i,a) 
+ (   1.00000) t1(i,j,a,b) v(i,a,j,b) 
+ (  -0.50000) t1(i,j,a,b) v(j,a,i,b) 
+ (   2.00000) t1(i,j,x,a) v(i,x,j,a) 
+ (  -1.00000) t1(i,j,x,a) v(j,x,i,a) 
+ (   1.00000) t1(i,j,x,y) v(i,x,j,y) 
+ (  -0.50000) t1(i,j,x,y) v(j,x,i,y) 
+ (  -1.00000) t1(i,x) v(i,j,j,x) 
+ (   2.00000) t1(i,x) v(j,j,i,x) 
+ (   1.00000) h(i,a) t1(i,x,a,y) trdm(x,y) 
+ (  -0.50000) h(i,a) t1(i,x,y,a) trdm(x,y) 
+ (  -0.50000) h(i,x) t1(i,y) trdm(x,y) 
+ (   1.00000) h(i,x) t1(i,y,x,z) trdm(y,z) 
+ (  -0.50000) h(i,x) t1(i,y,z,w) trdm(x,y,z,w) 
+ (  -0.50000) h(i,x) t1(i,y,z,x) trdm(y,z) 
+ (   0.50000) h(x,a) t1(y,a) trdm(y,x) 
+ (   0.50000) h(x,a) t1(y,z,w,a) trdm(z,y,x,w) 
+ (   1.00000) t1(i,a) v(i,a,x,y) trdm(y,x) 
+ (  -0.50000) t1(i,a) v(i,x,y,a) trdm(x,y) 
+ (  -1.00000) t1(i,j,x,a) v(i,y,j,a) trdm(y,x) 
+ (   0.50000) t1(i,j,x,a) v(j,y,i,a) trdm(y,x) 
+ (  -1.00000) t1(i,j,x,y) v(i,x,j,z) trdm(z,y) 
+ (   0.50000) t1(i,j,x,y) v(i,y,j,z) trdm(z,x) 
+ (   0.25000) t1(i,j,x,y) v(i,z,j,w) trdm(z,w,x,y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) trdm(y,x) 
+ (   1.00000) t1(i,x) v(i,x,y,z) trdm(z,y) 
+ (  -0.50000) t1(i,x) v(i,y,z,w) trdm(y,w,x,z) 
+ (  -0.50000) t1(i,x) v(i,y,z,x) trdm(y,z) 
+ (  -1.00000) t1(i,x) v(j,j,i,y) trdm(y,x) 
+ (   1.00000) t1(i,x,a,b) v(i,a,y,b) trdm(x,y) 
+ (  -0.50000) t1(i,x,a,b) v(i,b,y,a) trdm(x,y) 
+ (   1.00000) t1(i,x,a,y) v(i,a,z,w) trdm(x,w,y,z) 
+ (   1.00000) t1(i,x,a,y) v(i,a,z,y) trdm(x,z) 
+ (  -1.00000) t1(i,x,a,y) v(i,j,j,a) trdm(x,y) 
+ (  -0.50000) t1(i,x,a,y) v(i,y,z,a) trdm(x,z) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,w,a) trdm(x,z,y,w) 
+ (   2.00000) t1(i,x,a,y) v(j,j,i,a) trdm(x,y) 
+ (  -0.50000) t1(i,x,y,a) v(i,a,z,w) trdm(x,w,y,z) 
+ (  -0.50000) t1(i,x,y,a) v(i,a,z,y) trdm(x,z) 
+ (   0.50000) t1(i,x,y,a) v(i,j,j,a) trdm(x,y) 
+ (   1.00000) t1(i,x,y,a) v(i,y,z,a) trdm(x,z) 
+ (  -0.50000) t1(i,x,y,a) v(i,z,w,a) trdm(x,z,w,y) 
+ (  -1.00000) t1(i,x,y,a) v(j,j,i,a) trdm(x,y) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) trdm(x,w,z,y) 
+ (  -1.00000) t1(i,x,y,z) v(i,j,j,y) trdm(x,z) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,z) trdm(x,y) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(x,w,v,u,y,z) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(x,w,v,u,z,y) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(x,w,v,y,u,z) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(x,w,v,y,z,u) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(x,w,v,z,u,y) 
+ (  -0.33333) t1(i,x,y,z) v(i,w,u,v) trdm(x,w,v,z,y,u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,y) trdm(x,w,z,u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,z) trdm(x,w,u,y) 
+ (   1.00000) t1(i,x,y,z) v(i,y,w,u) trdm(x,u,z,w) 
+ (   1.00000) t1(i,x,y,z) v(i,y,w,z) trdm(x,w) 
+ (  -0.50000) t1(i,x,y,z) v(i,z,w,u) trdm(x,u,y,w) 
+ (  -0.50000) t1(i,x,y,z) v(i,z,w,y) trdm(x,w) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,w) trdm(x,w,z,y) 
+ (   2.00000) t1(i,x,y,z) v(j,j,i,y) trdm(x,z) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,z) trdm(x,y) 
+ (   1.00000) t1(x,a) v(i,i,y,a) trdm(x,y) 
+ (  -0.50000) t1(x,a) v(i,y,a,i) trdm(x,y) 
+ (   0.50000) t1(x,a) v(y,z,w,a) trdm(x,z,w,y) 
+ (   0.25000) t1(x,y,a,b) v(z,a,w,b) trdm(x,y,z,w) 
+ (   1.00000) t1(x,y,z,a) v(i,i,w,a) trdm(y,x,w,z) 
+ (  -0.50000) t1(x,y,z,a) v(i,w,a,i) trdm(y,x,w,z) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(y,x,u,v,w,z) 
+ (   0.33333) t1(x,y,z,a) v(w,u,v,a) trdm(y,x,u,v,z,w) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(y,x,u,w,v,z) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(y,x,u,w,z,v) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(y,x,u,z,v,w) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(y,x,u,z,w,v) 
+ (   0.50000) t1(x,y,z,a) v(w,z,u,a) trdm(x,y,w,u) 
+
+Total spin-integrated terms: 166
+Total spin-adapted terms: 77
+Spin-adaptation automation time :  12.669 seconds
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+
+--------------------------------------------- WARNING ----------------------------------------------
+
+Terms w/o transRDM tensor in the expression will be removed. Set "remove_trans_rdm_constant"
+flag to FALSE to preserve terms
+
+12 terms removed:
+ (   1.00000) h(i,a) t1(i,a) 
+ (   1.00000) h(i,x) t1(i,x) 
+ (  -1.00000) t1(i,a) v(i,j,j,a) 
+ (   2.00000) t1(i,a) v(j,j,i,a) 
+ (   1.00000) t1(i,j,a,b) v(i,a,j,b) 
+ (  -0.50000) t1(i,j,a,b) v(j,a,i,b) 
+ (   2.00000) t1(i,j,x,a) v(i,x,j,a) 
+ (  -1.00000) t1(i,j,x,a) v(j,x,i,a) 
+ (   1.00000) t1(i,j,x,y) v(i,x,j,y) 
+ (  -0.50000) t1(i,j,x,y) v(j,x,i,y) 
+ (  -1.00000) t1(i,x) v(i,j,j,x) 
+ (   2.00000) t1(i,x) v(j,j,i,x) 
+----------------------------------------------------------------------------------------------------
+Remaining terms: 65
+
+
+--------------------------------------------- WARNING ----------------------------------------------
+
+Terms with a contraction over repeating dummy core indices of 2e- integrals
+will be removed. Set "remove_core_integrals" flag to FALSE to preserve terms
+
+16 terms removed:
+ (   0.50000) t1(i,x) v(i,j,j,y) trdm(y,x) 
+ (  -1.00000) t1(i,x) v(j,j,i,y) trdm(y,x) 
+ (  -1.00000) t1(i,x,a,y) v(i,j,j,a) trdm(x,y) 
+ (   2.00000) t1(i,x,a,y) v(j,j,i,a) trdm(x,y) 
+ (   0.50000) t1(i,x,y,a) v(i,j,j,a) trdm(x,y) 
+ (  -1.00000) t1(i,x,y,a) v(j,j,i,a) trdm(x,y) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) trdm(x,w,z,y) 
+ (  -1.00000) t1(i,x,y,z) v(i,j,j,y) trdm(x,z) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,z) trdm(x,y) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,w) trdm(x,w,z,y) 
+ (   2.00000) t1(i,x,y,z) v(j,j,i,y) trdm(x,z) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,z) trdm(x,y) 
+ (   1.00000) t1(x,a) v(i,i,y,a) trdm(x,y) 
+ (  -0.50000) t1(x,a) v(i,y,a,i) trdm(x,y) 
+ (   1.00000) t1(x,y,z,a) v(i,i,w,a) trdm(y,x,w,z) 
+ (  -0.50000) t1(x,y,z,a) v(i,w,a,i) trdm(y,x,w,z) 
+----------------------------------------------------------------------------------------------------
+Remaining terms: 49
+
+
+--------------------------------------- genEinsum equations ----------------------------------------
+
+temp  = einsum('ia,ixay,xy', h_ce, t1_caea, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ia,ixya,xy', h_ce, t1_caae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iy,xy', h_ca, t1_ca, trdm_ca, optimize = einsum_type)
+temp += einsum('ix,iyxz,yz', h_ca, t1_caaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzw,xyzw', h_ca, t1_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzx,yz', h_ca, t1_caaa, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('xa,ya,yx', h_ae, t1_ae, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('xa,yzwa,zyxw', h_ae, t1_aaae, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ia,iaxy,yx', t1_ce, v_ceaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ia,ixya,xy', t1_ce, v_caae, trdm_ca, optimize = einsum_type)
+temp -= einsum('ijxa,iyja,yx', t1_ccae, v_cace, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('ijxa,jyia,yx', t1_ccae, v_cace, trdm_ca, optimize = einsum_type)
+temp -= einsum('ijxy,ixjz,zy', t1_ccaa, v_caca, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('ijxy,iyjz,zx', t1_ccaa, v_caca, trdm_ca, optimize = einsum_type)
+temp += 1/4 * einsum('ijxy,izjw,zwxy', t1_ccaa, v_caca, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ix,ixyz,zy', t1_ca, v_caaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzw,ywxz', t1_ca, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzx,yz', t1_ca, v_caaa, trdm_ca, optimize = einsum_type)
+temp += einsum('ixab,iayb,xy', t1_caee, v_ceae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixab,ibya,xy', t1_caee, v_ceae, trdm_ca, optimize = einsum_type)
+temp += einsum('ixay,iazw,xwyz', t1_caea, v_ceaa, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ixay,iazy,xz', t1_caea, v_ceaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixay,iyza,xz', t1_caea, v_caae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixay,izwa,xzyw', t1_caea, v_caae, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixya,iazw,xwyz', t1_caae, v_ceaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixya,iazy,xz', t1_caae, v_ceaa, trdm_ca, optimize = einsum_type)
+temp += einsum('ixya,iyza,xz', t1_caae, v_caae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixya,izwa,xzwy', t1_caae, v_caae, trdm_ccaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,xwvuyz', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,xwvuzy', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,xwvyuz', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,xwvyzu', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,xwvzuy', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/3 * einsum('ixyz,iwuv,xwvzyu', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,iwuy,xwzu', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,iwuz,xwuy', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ixyz,iywu,xuzw', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ixyz,iywz,xw', t1_caaa, v_caaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,izwu,xuyw', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,izwy,xw', t1_caaa, v_caaa, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('xa,yzwa,xzwy', t1_ae, v_aaae, trdm_ccaa, optimize = einsum_type)
+temp += 1/4 * einsum('xyab,zawb,xyzw', t1_aaee, v_aeae, trdm_ccaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,yxuvwz', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp += 1/3 * einsum('xyza,wuva,yxuvzw', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,yxuwvz', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,yxuwzv', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,yxuzvw', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,yxuzwv', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp += 1/2 * einsum('xyza,wzua,xywu', t1_aaae, v_aaae, trdm_ccaa, optimize = einsum_type)
+----------------------------------------------------------------------------------------------------
+> Total elapsed time: 77.46 seconds.

--- a/examples/QDNEVPT2/TV.py
+++ b/examples/QDNEVPT2/TV.py
@@ -1,0 +1,37 @@
+import sqa_plus
+sqa_plus.options.spin_integrated = True
+sqa_plus.options.genEinsum.remove_trans_rdm_constant = True
+sqa_plus.options.genEinsum.remove_core_integrals = True
+sqa_plus.options.genEinsum.trans_rdm = True
+sqa_plus.options.genEinsum.trans_indices_string = ""
+
+import time
+start = time.time()
+
+# Create spin-integrated V and T operators
+print("# Create spin-integrated V operator ...")
+terms_V = sqa_plus.Vperturbation()
+terms_T = sqa_plus.Tamplitude(1, only_deexcitations = True)
+
+# Multiply V * T
+print("\n## Calculate 0.5 * <|T+ * V|> ...")
+terms_VT = []
+for term_T in terms_T:
+    for term_V in terms_V:
+        terms_VT.append(sqa_plus.multiplyTerms(term_T, term_V))
+
+# Minus sign is necessary to compensate for the minus sign in the definition of T+
+for t in terms_VT:
+    t.scale(-0.5)
+
+# Evaluate term in spin-integrated form
+terms_VT_si = sqa_plus.matrixBlock(terms_VT)
+
+# Spin-adapt the resulting expression
+terms_VT_sa = sqa_plus.convertSpinIntegratedToAdapted(terms_VT_si)
+
+# Generate numpy code 
+result = sqa_plus.genEinsum(terms_VT_sa, "")
+
+end = time.time()
+print("> Total elapsed time: {:.2f} seconds.".format(end - start))

--- a/examples/QDNEVPT2/VT.dat
+++ b/examples/QDNEVPT2/VT.dat
@@ -1,0 +1,445 @@
+
+----------------------------------------------------------------------------------------------------
+sqa_plus: Code generator for quasi-particle systems.
+Copyright 2009-2022 SecondQuantizationAlgebra Developers. All Rights Reserved.
+Available at https://github.com/sokolov-group/sqa_plus
+
+Licensed under the GNU General Public License v3.0;
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+----------------------------------------------------------------------------------------------------
+
+# Create spin-integrated V operator ...
+
+## Calculate 0.5 * <|V * T|> ...
+
+------------------------------------------ SQA Automation ------------------------------------------
+
+Computing expectation value with respect to virtual ...
+Done!
+----------------------------------------------------------------------------------------------------
+Normal ordering with respect to core ...
+Done!
+----------------------------------------------------------------------------------------------------
+Computing expectation value with respect to core ...
+Done!
+----------------------------------------------------------------------------------------------------
+Contract delta function for non-dummy indices ...
+Done!
+----------------------------------------------------------------------------------------------------
+Reordering indices according to core < active < virtual...
+Done!
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+
+------------------------------------------ Final results -------------------------------------------
+
+ (   0.50000) h(i,x) t1(i,x) 
+ (   0.50000) h(i,a) t1(i,a) 
+ (   0.50000) h(i,x) t1(i,x) 
+ (   0.50000) h(i,a) t1(i,a) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (   0.12500) t1(i,j,x,y) v(i,j,x,y) 
+ (   0.25000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.12500) t1(i,j,a,b) v(i,j,a,b) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (   0.50000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.50000) t1(i,j,x,y) v(i,j,x,y) 
+ (   0.50000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.50000) t1(i,j,a,b) v(i,j,a,b) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (  -0.50000) t1(i,x) v(i,j,j,x) 
+ (   0.12500) t1(i,j,x,y) v(i,j,x,y) 
+ (   0.25000) t1(i,j,a,x) v(i,j,a,x) 
+ (   0.12500) t1(i,j,a,b) v(i,j,a,b) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (  -0.50000) t1(i,a) v(i,j,j,a) 
+ (  -0.50000) h(i,x) t1(i,y) cre(y) des(x) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(z) des(y) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(z) des(y) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(y) des(x) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(y) des(x) 
+ (   0.50000) h(x,a) t1(y,a) cre(x) des(y) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(z) des(y) 
+ (  -0.50000) h(i,x) t1(i,y) cre(y) des(x) 
+ (   0.50000) h(i,x) t1(i,y,x,z) cre(z) des(y) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(y) des(x) 
+ (   0.50000) h(i,a) t1(i,x,a,y) cre(y) des(x) 
+ (   0.50000) h(x,a) t1(y,a) cre(x) des(y) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(y) des(x) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(y) des(x) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(y) des(z) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(y) des(z) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(x) des(y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(x) des(y) 
+ (   0.25000) t1(i,x,y,z) v(i,w,y,z) cre(w) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (   0.25000) t1(i,x,a,b) v(i,y,a,b) cre(y) des(x) 
+ (  -0.25000) t1(i,j,x,y) v(i,j,x,z) cre(y) des(z) 
+ (  -0.25000) t1(i,j,a,x) v(i,j,a,y) cre(x) des(y) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(x) des(y) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(x) des(y) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (   0.50000) t1(i,x,y,z) v(i,w,y,z) cre(w) des(x) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(z) des(x) 
+ (   0.50000) t1(i,x,a,b) v(i,y,a,b) cre(y) des(x) 
+ (  -0.50000) t1(i,j,a,x) v(i,j,a,y) cre(x) des(y) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(y) des(x) 
+ (   0.50000) t1(x,a) v(i,y,i,a) cre(y) des(x) 
+ (   0.50000) t1(i,x,y,z) v(i,w,y,z) cre(w) des(x) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(z) des(x) 
+ (   0.50000) t1(i,x,a,b) v(i,y,a,b) cre(y) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (  -0.50000) t1(i,j,x,y) v(i,j,x,z) cre(y) des(z) 
+ (  -0.50000) t1(i,j,a,x) v(i,j,a,y) cre(x) des(y) 
+ (  -0.50000) t1(i,j,x,y) v(i,j,x,z) cre(y) des(z) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(y) des(z) 
+ (   0.50000) t1(i,x) v(i,y,x,z) cre(y) des(z) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(x) des(y) 
+ (   0.50000) t1(i,x) v(i,j,j,y) cre(x) des(y) 
+ (   0.25000) t1(i,x,y,z) v(i,w,y,z) cre(w) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,y,z) v(i,j,j,y) cre(z) des(x) 
+ (   0.50000) t1(i,x,a,y) v(i,z,a,y) cre(z) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (  -0.50000) t1(i,x,a,y) v(i,j,j,a) cre(y) des(x) 
+ (   0.25000) t1(i,x,a,b) v(i,y,a,b) cre(y) des(x) 
+ (  -0.25000) t1(i,j,x,y) v(i,j,x,z) cre(y) des(z) 
+ (  -0.25000) t1(i,j,a,x) v(i,j,a,y) cre(x) des(y) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(x) des(y) 
+ (   0.50000) t1(i,a) v(i,x,a,y) cre(x) des(y) 
+ (   0.25000) h(i,x) t1(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (   0.50000) h(i,x) t1(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (  -0.25000) h(x,a) t1(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.50000) h(x,a) t1(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (   0.50000) h(i,x) t1(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (   0.25000) h(i,x) t1(i,y,z,w) cre(z) cre(w) des(x) des(y) 
+ (  -0.50000) h(x,a) t1(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.25000) h(x,a) t1(y,z,a,w) cre(x) cre(w) des(y) des(z) 
+ (  -0.12500) t1(x,y,a,z) v(w,u,a,z) cre(w) cre(u) des(x) des(y) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (  -0.06250) t1(x,y,a,b) v(z,w,a,b) cre(z) cre(w) des(x) des(y) 
+ (  -0.25000) t1(x,a) v(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(x,a) v(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(x,y,a,z) v(w,u,a,z) cre(w) cre(u) des(x) des(y) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (   0.25000) t1(i,x) v(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (   0.50000) t1(i,x) v(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.06250) t1(i,j,x,y) v(i,j,z,w) cre(x) cre(y) des(z) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (   0.50000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (  -0.50000) t1(x,y,a,z) v(w,u,a,z) cre(w) cre(u) des(x) des(y) 
+ (  -0.50000) t1(x,y,a,b) v(z,w,a,b) cre(z) cre(w) des(x) des(y) 
+ (  -0.12500) t1(x,y,a,z) v(w,u,a,z) cre(w) cre(u) des(x) des(y) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (   0.25000) t1(x,y,a,z) v(i,w,i,a) cre(z) cre(w) des(x) des(y) 
+ (  -0.06250) t1(x,y,a,b) v(z,w,a,b) cre(z) cre(w) des(x) des(y) 
+ (  -0.50000) t1(x,a) v(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.25000) t1(x,a) v(y,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,j,x,y) v(i,j,z,w) cre(x) cre(y) des(z) des(w) 
+ (   0.50000) t1(i,x) v(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (   0.25000) t1(i,x) v(i,y,z,w) cre(x) cre(y) des(z) des(w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,y,u) cre(z) cre(w) des(x) des(u) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (   0.25000) t1(i,x,y,z) v(i,j,j,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,a,w) cre(y) cre(z) des(x) des(w) 
+ (  -0.06250) t1(i,j,x,y) v(i,j,z,w) cre(x) cre(y) des(z) des(w) 
+ (   0.12500) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (   0.50000) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (  -0.12500) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (   0.50000) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (   0.25000) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (   0.12500) t1(x,y,a,z) v(w,u,a,v) cre(z) cre(w) cre(u) des(x) des(y) des(v) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (  -0.25000) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+ (  -0.12500) t1(i,x,y,z) v(i,w,u,v) cre(y) cre(z) cre(w) des(x) des(u) des(v) 
+
+Total terms : 166
+SQA automation time :  61.696 seconds
+
+------------------------ Converting Spin-Integrated Tensors to Spin-Adapted ------------------------
+
+----------------------------------------------------------------------------------------------------
+Convert Cre/Des objects to RDM objects...
+Done!
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+Converting 1e- integrals to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+Converting 2e- integrals to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+Converting T amplitudes to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+Converting RDMs to spin-adapted formulation...
+
+Converting 1-RDMs to spin-adapted formulation...
+Converting 2-RDMs to spin-adapted formulation...
+Converting 3-RDMs to spin-adapted formulation...
+Converting 4-RDMs to spin-adapted formulation...
+Done!
+----------------------------------------------------------------------------------------------------
+
+Combining 556 spin-adapted terms...
+
+Reorder 2e- integrals in Chemists' notation...
+Done!
+----------------------------------------------------------------------------------------------------
+Reorder RDM tensor indices in Chemists' notation...
+Done!
+----------------------------------------------------------------------------------------------------
+Reordering indices according to core < active < virtual...
+Done!
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+
+479 spin-adapted terms combined.
+----------------------------------------------------------------------------------------------------
+
+-------------------------------------- Spin-adapted equations --------------------------------------
+
+ (   1.00000) h(i,a) t1(i,a) 
+ (   1.00000) h(i,x) t1(i,x) 
+ (  -1.00000) t1(i,a) v(i,j,j,a) 
+ (   2.00000) t1(i,a) v(j,j,i,a) 
+ (   1.00000) t1(i,j,a,b) v(i,a,j,b) 
+ (  -0.50000) t1(i,j,a,b) v(j,a,i,b) 
+ (   2.00000) t1(i,j,x,a) v(i,x,j,a) 
+ (  -1.00000) t1(i,j,x,a) v(j,x,i,a) 
+ (   1.00000) t1(i,j,x,y) v(i,x,j,y) 
+ (  -0.50000) t1(i,j,x,y) v(j,x,i,y) 
+ (  -1.00000) t1(i,x) v(i,j,j,x) 
+ (   2.00000) t1(i,x) v(j,j,i,x) 
+ (   1.00000) h(i,a) t1(i,x,a,y) trdm(y,x) 
+ (  -0.50000) h(i,a) t1(i,x,y,a) trdm(y,x) 
+ (  -0.50000) h(i,x) t1(i,y) trdm(y,x) 
+ (   1.00000) h(i,x) t1(i,y,x,z) trdm(z,y) 
+ (  -0.50000) h(i,x) t1(i,y,z,w) trdm(z,w,x,y) 
+ (  -0.50000) h(i,x) t1(i,y,z,x) trdm(z,y) 
+ (   0.50000) h(x,a) t1(y,a) trdm(x,y) 
+ (   0.50000) h(x,a) t1(y,z,w,a) trdm(x,w,z,y) 
+ (   1.00000) t1(i,a) v(i,a,x,y) trdm(x,y) 
+ (  -0.50000) t1(i,a) v(i,x,y,a) trdm(y,x) 
+ (  -1.00000) t1(i,j,x,a) v(i,y,j,a) trdm(x,y) 
+ (   0.50000) t1(i,j,x,a) v(j,y,i,a) trdm(x,y) 
+ (  -1.00000) t1(i,j,x,y) v(i,x,j,z) trdm(y,z) 
+ (   0.50000) t1(i,j,x,y) v(i,y,j,z) trdm(x,z) 
+ (   0.25000) t1(i,j,x,y) v(i,z,j,w) trdm(x,y,z,w) 
+ (   0.50000) t1(i,x) v(i,j,j,y) trdm(x,y) 
+ (   1.00000) t1(i,x) v(i,x,y,z) trdm(y,z) 
+ (  -0.50000) t1(i,x) v(i,y,z,w) trdm(x,z,y,w) 
+ (  -0.50000) t1(i,x) v(i,y,z,x) trdm(z,y) 
+ (  -1.00000) t1(i,x) v(j,j,i,y) trdm(x,y) 
+ (   1.00000) t1(i,x,a,b) v(i,a,y,b) trdm(y,x) 
+ (  -0.50000) t1(i,x,a,b) v(i,b,y,a) trdm(y,x) 
+ (   1.00000) t1(i,x,a,y) v(i,a,z,w) trdm(y,z,x,w) 
+ (   1.00000) t1(i,x,a,y) v(i,a,z,y) trdm(z,x) 
+ (  -1.00000) t1(i,x,a,y) v(i,j,j,a) trdm(y,x) 
+ (  -0.50000) t1(i,x,a,y) v(i,y,z,a) trdm(z,x) 
+ (  -0.50000) t1(i,x,a,y) v(i,z,w,a) trdm(y,w,x,z) 
+ (   2.00000) t1(i,x,a,y) v(j,j,i,a) trdm(y,x) 
+ (  -0.50000) t1(i,x,y,a) v(i,a,z,w) trdm(y,z,x,w) 
+ (  -0.50000) t1(i,x,y,a) v(i,a,z,y) trdm(z,x) 
+ (   0.50000) t1(i,x,y,a) v(i,j,j,a) trdm(y,x) 
+ (   1.00000) t1(i,x,y,a) v(i,y,z,a) trdm(z,x) 
+ (  -0.50000) t1(i,x,y,a) v(i,z,w,a) trdm(y,w,z,x) 
+ (  -1.00000) t1(i,x,y,a) v(j,j,i,a) trdm(y,x) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) trdm(y,z,w,x) 
+ (  -1.00000) t1(i,x,y,z) v(i,j,j,y) trdm(z,x) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,z) trdm(y,x) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(y,z,u,v,w,x) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(y,z,u,v,x,w) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(y,z,u,w,v,x) 
+ (  -0.33333) t1(i,x,y,z) v(i,w,u,v) trdm(y,z,u,w,x,v) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(y,z,u,x,v,w) 
+ (   0.16667) t1(i,x,y,z) v(i,w,u,v) trdm(y,z,u,x,w,v) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,y) trdm(z,u,x,w) 
+ (  -0.50000) t1(i,x,y,z) v(i,w,u,z) trdm(y,u,w,x) 
+ (   1.00000) t1(i,x,y,z) v(i,y,w,u) trdm(z,w,x,u) 
+ (   1.00000) t1(i,x,y,z) v(i,y,w,z) trdm(w,x) 
+ (  -0.50000) t1(i,x,y,z) v(i,z,w,u) trdm(y,w,x,u) 
+ (  -0.50000) t1(i,x,y,z) v(i,z,w,y) trdm(w,x) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,w) trdm(y,z,w,x) 
+ (   2.00000) t1(i,x,y,z) v(j,j,i,y) trdm(z,x) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,z) trdm(y,x) 
+ (   1.00000) t1(x,a) v(i,i,y,a) trdm(y,x) 
+ (  -0.50000) t1(x,a) v(i,y,a,i) trdm(y,x) 
+ (   0.50000) t1(x,a) v(y,z,w,a) trdm(w,y,x,z) 
+ (   0.25000) t1(x,y,a,b) v(z,a,w,b) trdm(z,w,x,y) 
+ (   1.00000) t1(x,y,z,a) v(i,i,w,a) trdm(z,w,x,y) 
+ (  -0.50000) t1(x,y,z,a) v(i,w,a,i) trdm(z,w,x,y) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(z,v,w,u,x,y) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(z,v,w,u,y,x) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(z,v,w,x,u,y) 
+ (   0.33333) t1(x,y,z,a) v(w,u,v,a) trdm(z,v,w,x,y,u) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(z,v,w,y,u,x) 
+ (  -0.16667) t1(x,y,z,a) v(w,u,v,a) trdm(z,v,w,y,x,u) 
+ (   0.50000) t1(x,y,z,a) v(w,z,u,a) trdm(w,u,x,y) 
+
+Total spin-integrated terms: 166
+Total spin-adapted terms: 77
+Spin-adaptation automation time :  12.566 seconds
+----------------------------------------------------------------------------------------------------
+Dummy indices relabelling...
+Done!
+----------------------------------------------------------------------------------------------------
+
+--------------------------------------------- WARNING ----------------------------------------------
+
+Terms w/o transRDM tensor in the expression will be removed. Set "remove_trans_rdm_constant"
+flag to FALSE to preserve terms
+
+12 terms removed:
+ (   1.00000) h(i,a) t1(i,a) 
+ (   1.00000) h(i,x) t1(i,x) 
+ (  -1.00000) t1(i,a) v(i,j,j,a) 
+ (   2.00000) t1(i,a) v(j,j,i,a) 
+ (   1.00000) t1(i,j,a,b) v(i,a,j,b) 
+ (  -0.50000) t1(i,j,a,b) v(j,a,i,b) 
+ (   2.00000) t1(i,j,x,a) v(i,x,j,a) 
+ (  -1.00000) t1(i,j,x,a) v(j,x,i,a) 
+ (   1.00000) t1(i,j,x,y) v(i,x,j,y) 
+ (  -0.50000) t1(i,j,x,y) v(j,x,i,y) 
+ (  -1.00000) t1(i,x) v(i,j,j,x) 
+ (   2.00000) t1(i,x) v(j,j,i,x) 
+----------------------------------------------------------------------------------------------------
+Remaining terms: 65
+
+
+--------------------------------------------- WARNING ----------------------------------------------
+
+Terms with a contraction over repeating dummy core indices of 2e- integrals
+will be removed. Set "remove_core_integrals" flag to FALSE to preserve terms
+
+16 terms removed:
+ (   0.50000) t1(i,x) v(i,j,j,y) trdm(x,y) 
+ (  -1.00000) t1(i,x) v(j,j,i,y) trdm(x,y) 
+ (  -1.00000) t1(i,x,a,y) v(i,j,j,a) trdm(y,x) 
+ (   2.00000) t1(i,x,a,y) v(j,j,i,a) trdm(y,x) 
+ (   0.50000) t1(i,x,y,a) v(i,j,j,a) trdm(y,x) 
+ (  -1.00000) t1(i,x,y,a) v(j,j,i,a) trdm(y,x) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,w) trdm(y,z,w,x) 
+ (  -1.00000) t1(i,x,y,z) v(i,j,j,y) trdm(z,x) 
+ (   0.50000) t1(i,x,y,z) v(i,j,j,z) trdm(y,x) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,w) trdm(y,z,w,x) 
+ (   2.00000) t1(i,x,y,z) v(j,j,i,y) trdm(z,x) 
+ (  -1.00000) t1(i,x,y,z) v(j,j,i,z) trdm(y,x) 
+ (   1.00000) t1(x,a) v(i,i,y,a) trdm(y,x) 
+ (  -0.50000) t1(x,a) v(i,y,a,i) trdm(y,x) 
+ (   1.00000) t1(x,y,z,a) v(i,i,w,a) trdm(z,w,x,y) 
+ (  -0.50000) t1(x,y,z,a) v(i,w,a,i) trdm(z,w,x,y) 
+----------------------------------------------------------------------------------------------------
+Remaining terms: 49
+
+
+--------------------------------------- genEinsum equations ----------------------------------------
+
+temp  = einsum('ia,ixay,yx', h_ce, t1_caea, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ia,ixya,yx', h_ce, t1_caae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iy,yx', h_ca, t1_ca, trdm_ca, optimize = einsum_type)
+temp += einsum('ix,iyxz,zy', h_ca, t1_caaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzw,zwxy', h_ca, t1_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzx,zy', h_ca, t1_caaa, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('xa,ya,xy', h_ae, t1_ae, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('xa,yzwa,xwzy', h_ae, t1_aaae, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ia,iaxy,xy', t1_ce, v_ceaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ia,ixya,yx', t1_ce, v_caae, trdm_ca, optimize = einsum_type)
+temp -= einsum('ijxa,iyja,xy', t1_ccae, v_cace, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('ijxa,jyia,xy', t1_ccae, v_cace, trdm_ca, optimize = einsum_type)
+temp -= einsum('ijxy,ixjz,yz', t1_ccaa, v_caca, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('ijxy,iyjz,xz', t1_ccaa, v_caca, trdm_ca, optimize = einsum_type)
+temp += 1/4 * einsum('ijxy,izjw,xyzw', t1_ccaa, v_caca, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ix,ixyz,yz', t1_ca, v_caaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzw,xzyw', t1_ca, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ix,iyzx,zy', t1_ca, v_caaa, trdm_ca, optimize = einsum_type)
+temp += einsum('ixab,iayb,yx', t1_caee, v_ceae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixab,ibya,yx', t1_caee, v_ceae, trdm_ca, optimize = einsum_type)
+temp += einsum('ixay,iazw,yzxw', t1_caea, v_ceaa, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ixay,iazy,zx', t1_caea, v_ceaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixay,iyza,zx', t1_caea, v_caae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixay,izwa,ywxz', t1_caea, v_caae, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixya,iazw,yzxw', t1_caae, v_ceaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixya,iazy,zx', t1_caae, v_ceaa, trdm_ca, optimize = einsum_type)
+temp += einsum('ixya,iyza,zx', t1_caae, v_caae, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixya,izwa,ywzx', t1_caae, v_caae, trdm_ccaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,yzuvwx', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,yzuvxw', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,yzuwvx', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/3 * einsum('ixyz,iwuv,yzuwxv', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,yzuxvw', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp += 1/6 * einsum('ixyz,iwuv,yzuxwv', t1_caaa, v_caaa, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,iwuy,zuxw', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,iwuz,yuwx', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ixyz,iywu,zwxu', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp += einsum('ixyz,iywz,wx', t1_caaa, v_caaa, trdm_ca, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,izwu,ywxu', t1_caaa, v_caaa, trdm_ccaa, optimize = einsum_type)
+temp -= 1/2 * einsum('ixyz,izwy,wx', t1_caaa, v_caaa, trdm_ca, optimize = einsum_type)
+temp += 1/2 * einsum('xa,yzwa,wyxz', t1_ae, v_aaae, trdm_ccaa, optimize = einsum_type)
+temp += 1/4 * einsum('xyab,zawb,zwxy', t1_aaee, v_aeae, trdm_ccaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,zvwuxy', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,zvwuyx', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,zvwxuy', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp += 1/3 * einsum('xyza,wuva,zvwxyu', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,zvwyux', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp -= 1/6 * einsum('xyza,wuva,zvwyxu', t1_aaae, v_aaae, trdm_cccaaa, optimize = einsum_type)
+temp += 1/2 * einsum('xyza,wzua,wuxy', t1_aaae, v_aaae, trdm_ccaa, optimize = einsum_type)
+----------------------------------------------------------------------------------------------------
+> Total elapsed time: 75.70 seconds.

--- a/examples/QDNEVPT2/VT.py
+++ b/examples/QDNEVPT2/VT.py
@@ -1,0 +1,37 @@
+import sqa_plus
+#sqa_plus.options.verbose = True
+sqa_plus.options.spin_integrated = True
+sqa_plus.options.genEinsum.remove_trans_rdm_constant = True
+sqa_plus.options.genEinsum.remove_core_integrals = True
+sqa_plus.options.genEinsum.trans_rdm = True
+sqa_plus.options.genEinsum.trans_indices_string = ""
+
+import time
+start = time.time()
+
+# Create spin-integrated V and T operators
+print("# Create spin-integrated V operator ...")
+terms_V = sqa_plus.Vperturbation()
+terms_T = sqa_plus.Tamplitude(1, only_excitations = True)
+
+# Multiply V * T
+print("\n## Calculate 0.5 * <|V * T|> ...")
+terms_VT = []
+for term_T in terms_T:
+    for term_V in terms_V:
+        terms_VT.append(sqa_plus.multiplyTerms(term_V, term_T))
+
+for t in terms_VT:
+    t.scale(0.5)
+
+# Evaluate term in spin-integrated form
+terms_VT_si = sqa_plus.matrixBlock(terms_VT)
+
+# Spin-adapt the resulting expression
+terms_VT_sa = sqa_plus.convertSpinIntegratedToAdapted(terms_VT_si)
+
+# Generate numpy code 
+result = sqa_plus.genEinsum(terms_VT_sa, "")
+
+end = time.time()
+print("> Total elapsed time: {:.2f} seconds.".format(end - start))

--- a/sqaSpinAdapted.py
+++ b/sqaSpinAdapted.py
@@ -66,8 +66,8 @@ def convertSpinIntegratedToAdapted(terms_si):
     terms_sa = convert_v2e_si_to_sa(terms_sa)
     print("Number of terms after convert_v2e_si_to_sa:", len(terms_sa))
 
-    for p in terms_sa:
-        print(p)
+    #for p in terms_sa:
+    #    print(p)
 
     # Convert T amplitudes to Spin-Adapted Formulation
     terms_sa = convert_t_amplitudes_si_to_sa(terms_sa)
@@ -75,7 +75,7 @@ def convertSpinIntegratedToAdapted(terms_si):
 
     for p in terms_sa:
         print(p)
-    exit()
+    # exit()
 
     # Convert custom tensors using user-defined Spin-Adapted Functions
     if custom_functions:
@@ -126,7 +126,7 @@ def convertSpinIntegratedToAdapted(terms_si):
 
     print("Number of terms after combineTerms:", len(terms_sa))
 
-    exit()
+    #exit()
 
     ##### DEBUG AREA ######
 
@@ -5479,7 +5479,7 @@ def convert_t_amplitudes_si_to_sa(_terms_t_si):
         tens_t2_ind = []
 
         for ten_ind, ten in enumerate(term_t2_si.tensors):
-            if ten.name[0] == 't' and len(ten.indices) == 4:
+            if ten.name[0] == 't' and len(ten.indices) == 4 and ten.name != 'trdm':
                 tens_t2.append(ten)
                 tens_t2_ind.append(ten_ind)
 

--- a/sqaSpinAdapted.py
+++ b/sqaSpinAdapted.py
@@ -35,6 +35,7 @@ def convertSpinIntegratedToAdapted(terms_si):
     custom_functions = options.convertSpinIntegratedToAdapted.custom_functions
     improve_3rdms_combinations = options.convertSpinIntegratedToAdapted.improve_3rdms_combinations
     improve_4rdms_combinations = options.convertSpinIntegratedToAdapted.improve_4rdms_combinations
+    trans_rdm = options.genEinsum.trans_rdm
 
     startTime = time.time()
     options.print_header("Converting Spin-Integrated Tensors to Spin-Adapted")
@@ -42,7 +43,7 @@ def convertSpinIntegratedToAdapted(terms_si):
 
     # Convert Cre/Des Objects to RDM Objects
     options.print_divider()
-    convert_credes_to_rdm(terms_si, trans_rdm = False)
+    convert_credes_to_rdm(terms_si, trans_rdm = trans_rdm)
 
     dummyLabel(terms_si)
     len_terms_si = len(terms_si)
@@ -89,7 +90,7 @@ def convertSpinIntegratedToAdapted(terms_si):
     terms_sa = convert_rdms_si_to_sa(terms_sa)
 
     # Update Spin-Adapted Symmetries in tensors
-    update_sa_tensors_symmetries(terms_sa)
+    update_sa_tensors_symmetries(terms_sa, trans_rdm)
 
     # Combine Spin-Adapted Terms
     options.print_divider()
@@ -102,7 +103,7 @@ def convertSpinIntegratedToAdapted(terms_si):
 
     # Reorder tensors to Chemist's Notation
     reorder_v2e_indices_notation(terms_sa)
-    reorder_rdm_indices_notation(terms_sa)
+    reorder_rdm_indices_notation(terms_sa, trans_rdm)
     options.chemists_notation = True
 
     reorder_tensor_indices(terms_sa)
@@ -197,7 +198,7 @@ def reorder_v2e_indices_notation(_terms_v2e):
     sys.stdout.flush()
     return
 
-def reorder_rdm_indices_notation(_terms_rdm):
+def reorder_rdm_indices_notation(_terms_rdm, trans_rdm = False):
     print("Reorder RDM tensor indices in Chemists' notation...")
     sys.stdout.flush()
 
@@ -214,12 +215,20 @@ def reorder_rdm_indices_notation(_terms_rdm):
         rdm_tensors_ind = []
 
         ## Define indices symmetries
-        rdm2_symm = [symmetry((1,0,3,2), 1), symmetry((2,3,0,1), 1)]
+        if trans_rdm: 
+            rdm2_symm = [symmetry((1,0,3,2), 1)]
 
-        rdm3_symm = [symmetry((1,0,2,4,3,5), 1), symmetry((0,2,1,3,5,4), 1), symmetry((3,4,5,0,1,2), 1)]
+            rdm3_symm = [symmetry((1,0,2,4,3,5), 1), symmetry((0,2,1,3,5,4), 1)]
 
-        rdm4_symm = [symmetry((1,0,2,3,5,4,6,7), 1), symmetry((0,2,1,3,4,6,5,7), 1),
-                     symmetry((0,1,3,2,4,5,7,6), 1), symmetry((4,5,6,7,0,1,2,3), 1)]
+            rdm4_symm = [symmetry((1,0,2,3,5,4,6,7), 1), symmetry((0,2,1,3,4,6,5,7), 1),
+                         symmetry((0,1,3,2,4,5,7,6), 1)]
+        else:
+            rdm2_symm = [symmetry((1,0,3,2), 1), symmetry((2,3,0,1), 1)]
+
+            rdm3_symm = [symmetry((1,0,2,4,3,5), 1), symmetry((0,2,1,3,5,4), 1), symmetry((3,4,5,0,1,2), 1)]
+
+            rdm4_symm = [symmetry((1,0,2,3,5,4,6,7), 1), symmetry((0,2,1,3,4,6,5,7), 1),
+                         symmetry((0,1,3,2,4,5,7,6), 1), symmetry((4,5,6,7,0,1,2,3), 1)]
 
         ## Append all RDM objects to list
         for ten_rdm_ind, ten_rdm in enumerate(term_rdm.tensors):
@@ -5725,7 +5734,7 @@ def remove_si_tensors_symmetries(_terms_si):
             elif _tensor_si.name in ['t1', 't2'] and len(_tensor_si.indices) in [2, 4]:
                 _terms_si[_term_ind].tensors[_tensor_ind].symmetries = []
 
-def update_sa_tensors_symmetries(_terms_sa):
+def update_sa_tensors_symmetries(_terms_sa, trans_rdm = False):
     "Update Symmetries of Spin-Adapted Tensors"
 
     # Define Spin-Adapted Symmetries
@@ -5737,11 +5746,17 @@ def update_sa_tensors_symmetries(_terms_sa):
     t1_sa_symm = [symmetry((1,0), 1)]
     t2_sa_symm = [symmetry((1,0,3,2), 1), symmetry((2,3,0,1), 1)]
 
-    rdm1_sa_symm = [symmetry((1,0), 1)]
-    rdm2_sa_symm = [symmetry((1,0,3,2), 1), symmetry((3,2,1,0), 1)]
-    rdm3_sa_symm = [symmetry((1,0,2,3,5,4), 1), symmetry((0,2,1,4,3,5), 1), symmetry((5,4,3,2,1,0), 1)]
-    rdm4_sa_symm = [symmetry((1,0,2,3,4,5,7,6), 1), symmetry((0,2,1,3,4,6,5,7), 1), symmetry((0,1,3,2,5,4,6,7), 1),
-                    symmetry((7,6,5,4,3,2,1,0), 1)]
+    if trans_rdm:
+        rdm1_sa_symm = []
+        rdm2_sa_symm = [symmetry((1,0,3,2), 1)]
+        rdm3_sa_symm = [symmetry((1,0,2,3,5,4), 1), symmetry((0,2,1,4,3,5), 1)]
+        rdm4_sa_symm = [symmetry((1,0,2,3,4,5,7,6), 1), symmetry((0,2,1,3,4,6,5,7), 1), symmetry((0,1,3,2,5,4,6,7), 1)]
+    else:
+        rdm1_sa_symm = [symmetry((1,0), 1)]
+        rdm2_sa_symm = [symmetry((1,0,3,2), 1), symmetry((3,2,1,0), 1)]
+        rdm3_sa_symm = [symmetry((1,0,2,3,5,4), 1), symmetry((0,2,1,4,3,5), 1), symmetry((5,4,3,2,1,0), 1)]
+        rdm4_sa_symm = [symmetry((1,0,2,3,4,5,7,6), 1), symmetry((0,2,1,3,4,6,5,7), 1), symmetry((0,1,3,2,5,4,6,7), 1),
+                        symmetry((7,6,5,4,3,2,1,0), 1)]
 
     for _term_ind, _term_sa in enumerate(_terms_sa):
         for _tensor_ind, _tensor_sa in enumerate(_term_sa.tensors):

--- a/sqaSpinAdapted.py
+++ b/sqaSpinAdapted.py
@@ -43,22 +43,39 @@ def convertSpinIntegratedToAdapted(terms_si):
 
     # Convert Cre/Des Objects to RDM Objects
     options.print_divider()
+    ##### DEBUG AREA ######
+    print("Number of terms before convert_credes_to_rdm:", len(terms_si))
     convert_credes_to_rdm(terms_si, trans_rdm = trans_rdm)
 
+    print("Number of terms after convert_credes_to_rdm:", len(terms_si))
     dummyLabel(terms_si)
     len_terms_si = len(terms_si)
+
+    print("Number of terms after dummyLabel:", len(terms_si))
 
     # Temporarily remove spin-integrated symmetries of non-RDM tensors
     remove_si_tensors_symmetries(terms_si)
 
+    print("Number of terms after remove_si_tensors_symmetries:", len(terms_si))
+
     # Convert 1e- integrals to Spin-Adapted Formulation
     terms_sa = convert_h1e_si_to_sa(terms_si)
+    print("Number of terms after convert_h1e_si_to_sa:", len(terms_sa))
 
     # Convert 2e- integrals to Spin-Adapted Formulation
     terms_sa = convert_v2e_si_to_sa(terms_sa)
+    print("Number of terms after convert_v2e_si_to_sa:", len(terms_sa))
+
+    for p in terms_sa:
+        print(p)
 
     # Convert T amplitudes to Spin-Adapted Formulation
     terms_sa = convert_t_amplitudes_si_to_sa(terms_sa)
+    print("Number of terms after convert_t_amplitudes_si_to_sa:", len(terms_sa))
+
+    for p in terms_sa:
+        print(p)
+    exit()
 
     # Convert custom tensors using user-defined Spin-Adapted Functions
     if custom_functions:
@@ -86,11 +103,17 @@ def convertSpinIntegratedToAdapted(terms_si):
                 term_sa.isInCanonicalForm = False
                 term_sa.makeCanonical()
 
+    print("Number of terms after improve_3rdms_combinations:", len(terms_sa))
+
     # Convert RDMs to Spin-Adapted Formulation
     terms_sa = convert_rdms_si_to_sa(terms_sa)
 
+    print("Number of terms after convert_rdms_si_to_sa:", len(terms_sa))
+
     # Update Spin-Adapted Symmetries in tensors
     update_sa_tensors_symmetries(terms_sa, trans_rdm)
+
+    print("Number of terms after update_sa_tensors_symmetries:", len(terms_sa))
 
     # Combine Spin-Adapted Terms
     options.print_divider()
@@ -100,6 +123,12 @@ def convertSpinIntegratedToAdapted(terms_si):
     num_terms_sa = len(terms_sa)
     print("\nCombining {:} spin-adapted terms...\n".format(num_terms_sa))
     combineTerms(terms_sa)
+
+    print("Number of terms after combineTerms:", len(terms_sa))
+
+    exit()
+
+    ##### DEBUG AREA ######
 
     # Reorder tensors to Chemist's Notation
     reorder_v2e_indices_notation(terms_sa)
@@ -148,6 +177,9 @@ def convert_credes_to_rdm(_terms_credes, trans_rdm = False):
         if credes_ops:
             _terms_credes[term_credes_ind].tensors = [tens for tens in term_credes.tensors if tens not in credes_ops]
             ten_rdm = creDesTensor(credes_ops, trans_rdm)
+            print(ten_rdm)
+            for p in ten_rdm.symmetries:
+                print(str(p))
             _terms_credes[term_credes_ind].tensors.append(ten_rdm)
 
     print("Done!")

--- a/sqaSpinAdapted.py
+++ b/sqaSpinAdapted.py
@@ -43,39 +43,22 @@ def convertSpinIntegratedToAdapted(terms_si):
 
     # Convert Cre/Des Objects to RDM Objects
     options.print_divider()
-    ##### DEBUG AREA ######
-    print("Number of terms before convert_credes_to_rdm:", len(terms_si))
     convert_credes_to_rdm(terms_si, trans_rdm = trans_rdm)
 
-    print("Number of terms after convert_credes_to_rdm:", len(terms_si))
     dummyLabel(terms_si)
     len_terms_si = len(terms_si)
-
-    print("Number of terms after dummyLabel:", len(terms_si))
 
     # Temporarily remove spin-integrated symmetries of non-RDM tensors
     remove_si_tensors_symmetries(terms_si)
 
-    print("Number of terms after remove_si_tensors_symmetries:", len(terms_si))
-
     # Convert 1e- integrals to Spin-Adapted Formulation
     terms_sa = convert_h1e_si_to_sa(terms_si)
-    print("Number of terms after convert_h1e_si_to_sa:", len(terms_sa))
 
     # Convert 2e- integrals to Spin-Adapted Formulation
     terms_sa = convert_v2e_si_to_sa(terms_sa)
-    print("Number of terms after convert_v2e_si_to_sa:", len(terms_sa))
-
-    #for p in terms_sa:
-    #    print(p)
 
     # Convert T amplitudes to Spin-Adapted Formulation
     terms_sa = convert_t_amplitudes_si_to_sa(terms_sa)
-    print("Number of terms after convert_t_amplitudes_si_to_sa:", len(terms_sa))
-
-    for p in terms_sa:
-        print(p)
-    # exit()
 
     # Convert custom tensors using user-defined Spin-Adapted Functions
     if custom_functions:
@@ -103,17 +86,11 @@ def convertSpinIntegratedToAdapted(terms_si):
                 term_sa.isInCanonicalForm = False
                 term_sa.makeCanonical()
 
-    print("Number of terms after improve_3rdms_combinations:", len(terms_sa))
-
     # Convert RDMs to Spin-Adapted Formulation
     terms_sa = convert_rdms_si_to_sa(terms_sa)
 
-    print("Number of terms after convert_rdms_si_to_sa:", len(terms_sa))
-
     # Update Spin-Adapted Symmetries in tensors
     update_sa_tensors_symmetries(terms_sa, trans_rdm)
-
-    print("Number of terms after update_sa_tensors_symmetries:", len(terms_sa))
 
     # Combine Spin-Adapted Terms
     options.print_divider()
@@ -123,12 +100,6 @@ def convertSpinIntegratedToAdapted(terms_si):
     num_terms_sa = len(terms_sa)
     print("\nCombining {:} spin-adapted terms...\n".format(num_terms_sa))
     combineTerms(terms_sa)
-
-    print("Number of terms after combineTerms:", len(terms_sa))
-
-    #exit()
-
-    ##### DEBUG AREA ######
 
     # Reorder tensors to Chemist's Notation
     reorder_v2e_indices_notation(terms_sa)
@@ -177,9 +148,6 @@ def convert_credes_to_rdm(_terms_credes, trans_rdm = False):
         if credes_ops:
             _terms_credes[term_credes_ind].tensors = [tens for tens in term_credes.tensors if tens not in credes_ops]
             ten_rdm = creDesTensor(credes_ops, trans_rdm)
-            print(ten_rdm)
-            for p in ten_rdm.symmetries:
-                print(str(p))
             _terms_credes[term_credes_ind].tensors.append(ten_rdm)
 
     print("Done!")

--- a/sqaSpinAdapted.py
+++ b/sqaSpinAdapted.py
@@ -5401,13 +5401,15 @@ def convert_t_amplitudes_si_to_sa(_terms_t_si):
     inds_aa = [options.alpha_type, options.alpha_type]
     inds_bb = [options.beta_type,  options.beta_type]
 
+    t_amp_tensor_name = ['t1', 't2', 't3', 't4']
+
     # Convert One-Body Amplitudes
     terms_t1_sa = []
     for term_t1_si in _terms_t_si:
         term_t1_sa = term_t1_si.copy()
 
         for ten_ind, ten in enumerate(term_t1_sa.tensors):
-            if ten.name[0] == 't' and len(ten.indices) == 2:
+            if ten.name in t_amp_tensor_name and len(ten.indices) == 2:
                 ten_t1_spin_inds = [get_spin_index_type(ind) for ind in ten.indices]
 
                 if options.verbose:
@@ -5447,7 +5449,7 @@ def convert_t_amplitudes_si_to_sa(_terms_t_si):
         tens_t2_ind = []
 
         for ten_ind, ten in enumerate(term_t2_si.tensors):
-            if ten.name[0] == 't' and len(ten.indices) == 4 and ten.name != 'trdm':
+            if ten.name in t_amp_tensor_name and len(ten.indices) == 4:
                 tens_t2.append(ten)
                 tens_t2_ind.append(ten_ind)
 


### PR DESCRIPTION
This PR enables the derivation of spin-adapted matrix elements between different bra and ket. It also fixes a bug in the spin adaptation of t-amplitudes that arises when a tensor starts with 't'. 